### PR TITLE
About “hal” changed to “cha32_hal” for newcomers to understand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@
 
 use embassy_executor::Spawner;
 use embassy_time::Timer;
-use hal::gpio::{AnyPin, Level, Output, Pin};
-use hal::println;
-use {ch32_hal as hal, panic_halt as _};
+use ch32_hal::gpio::{AnyPin, Level, Output, Pin};
+use ch32_hal::println;
+use {ch32_hal, panic_halt as _};
 
 #[embassy_executor::task]
 async fn blink(pin: AnyPin, interval_ms: u64) {


### PR DESCRIPTION
I didn't really understand how "hal" came about, and finally wrote use "cha32_hal as hal", which is easy to understand, can you fix it?